### PR TITLE
test_data_path, model_ckpt_path, and --output_dir

### DIFF
--- a/elm_classification/options/base_arguments.py
+++ b/elm_classification/options/base_arguments.py
@@ -36,6 +36,12 @@ class BaseArguments:
             help="path to the pretrained weights of the saved models.",
         )
         parser.add_argument(
+            "--output_dir",
+            type=str,
+            default="outputs",
+            help="path to the inference outputs.",
+        )
+        parser.add_argument(
             "--use_all_data",
             action="store_true",
             default=False,

--- a/elm_classification/src/utils.py
+++ b/elm_classification/src/utils.py
@@ -143,23 +143,14 @@ def create_data(data_name: str):
 def create_output_paths(
     args: argparse.Namespace, infer_mode: bool = False
 ) -> Tuple[str]:
-    if args.signal_window_size == 8:
-        test_data_path = os.path.join(args.test_data_dir, "signal_window_8")
-        model_ckpt_path = os.path.join(args.model_ckpts, "signal_window_8")
-    elif args.signal_window_size == 16:
-        test_data_path = os.path.join(args.test_data_dir, "signal_window_16")
-        model_ckpt_path = os.path.join(args.model_ckpts, "signal_window_16")
-    else:
-        test_data_path = os.path.join(
-            args.test_data_dir, f"signal_window_{args.signal_window_size}"
-        )
-        model_ckpt_path = os.path.join(
-            args.model_ckpts, f"signal_window_{args.signal_window_size}"
-        )
-    if not os.path.exists(test_data_path):  # moved outside of previous `else` clause
-        os.makedirs(test_data_path, exist_ok=True)
-    if not os.path.exists(model_ckpt_path):  # moved outside of previous `else` clause
-        os.makedirs(model_ckpt_path, exist_ok=True)
+    test_data_path = os.path.join(
+        args.test_data_dir, f"signal_window_{args.signal_window_size}"
+    )
+    model_ckpt_path = os.path.join(
+        args.model_ckpts, f"signal_window_{args.signal_window_size}"
+    )
+    os.makedirs(test_data_path, exist_ok=True)
+    os.makedirs(model_ckpt_path, exist_ok=True)
     if infer_mode:
         if args.signal_window_size == 8:
             base_path = os.path.join(args.output_dir, "signal_window_8")


### PR DESCRIPTION
1) added `--output_dir` in `base_arguments.py` (previously, `--output_dir` was only in `test_arguments.py`)
2) simplified logic for `test_data_path` and `model_ckpt_path` in `utils.create_output_paths()`
